### PR TITLE
Added a janky LinkUpgrader

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "push-main": "rollup -c --environment DEST:main",
     "push-pserver": "rollup -c --environment DEST:pserver",
     "push-sim": "rollup -c --environment DEST:sim",
+    "push-season": "rollup -c --environment DEST:season",
     "push-local": "rollup -c && cp dist/* /Users/brisberg/Library/Application\\ Support/Screeps/scripts/screeps.com/sim/",
     "test": "yarn run test-unit && yarn run test-integration",
     "test-unit": "jest",
@@ -39,6 +40,7 @@
     "watch-main": "rollup -cw --environment DEST:main",
     "watch-pserver": "rollup -cw --environment DEST:pserver",
     "watch-sim": "rollup -cw --environment DEST:sim",
+    "watch-season": "rollup -cw --environment DEST:season",
     "lint": "eslint \"src/**/*.ts\""
   },
   "dependencies": {

--- a/src/behaviors/index.ts
+++ b/src/behaviors/index.ts
@@ -15,19 +15,20 @@ import {ENET_FETCHER, ENetFetcher} from './eNetFetcher';
 import {Fetcher, FETCHER} from './fetcher';
 import {Harvester, HARVESTER} from './harvester';
 import {Idler, IDLER} from './idler';
+import {LINK_UPGRADER, LinkUpgrader} from './linkUpgrader';
 import {Pioneer, PIONEER} from './pioneer';
 import {Repairer, REPAIRER} from './repairer';
 import {SENTRY, Sentry} from './sentry';
 import {SOURCE_BUILDER, SourceBuilder} from './sourceBuilder';
 import {Upgrader, UPGRADER} from './upgrader';
 
-export type BehaviorKey =
-    typeof ATTACKER|typeof PIONEER|typeof REPAIRER|typeof FETCHER|
-    typeof DEPOSITER|typeof CONTAINER_HARVESTER|typeof EMERGENCY_MINER|
-    typeof BUILDER|typeof SOURCE_BUILDER|typeof ENET_BUILDER|
-    typeof ENET_FETCHER|typeof ENET_DEPOSITER|typeof UPGRADER|
-    typeof CONTAINER_UPGRADER|typeof DISTRIBUTOR|typeof DEMOLISHER|
-    typeof CLAIMER|typeof CLAIM_ATTTACK|typeof SENTRY|typeof IDLER;
+export type BehaviorKey = typeof ATTACKER|typeof PIONEER|typeof REPAIRER|
+    typeof FETCHER|typeof DEPOSITER|typeof CONTAINER_HARVESTER|
+    typeof EMERGENCY_MINER|typeof BUILDER|typeof SOURCE_BUILDER|
+    typeof ENET_BUILDER|typeof ENET_FETCHER|typeof ENET_DEPOSITER|
+    typeof UPGRADER|typeof CONTAINER_UPGRADER|typeof LINK_UPGRADER|
+    typeof DISTRIBUTOR|typeof DEMOLISHER|typeof CLAIMER|typeof CLAIM_ATTTACK|
+    typeof SENTRY|typeof IDLER;
 
 export interface BehaviorMap {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -51,6 +52,7 @@ global.behaviors = {
   [ENET_DEPOSITER]: new ENetDepositer(),
   [UPGRADER]: new Upgrader(),
   [CONTAINER_UPGRADER]: new ContainerUpgrader(),
+  [LINK_UPGRADER]: new LinkUpgrader(),
   [DISTRIBUTOR]: new Distributor(),
   [DEMOLISHER]: new Demolisher(),
   [CLAIMER]: new Claimer(),

--- a/src/behaviors/linkUpgrader.ts
+++ b/src/behaviors/linkUpgrader.ts
@@ -1,0 +1,105 @@
+import {Behavior, BehaviorMemory} from './behavior';
+import {Upgrader, UPGRADER} from './upgrader';
+
+interface LinkUpgraderMemory extends BehaviorMemory {
+  controllerID: Id<StructureController>;
+  linkID: Id<StructureLink>;
+  destPos?: [number, number];
+}
+
+export const LINK_UPGRADER = 'link-upgrader';
+
+/**
+ * TODO: Unify this with the container option
+ * Creep behavior class for a single creep to upgrade a Room Controller from a
+ * Link.
+ *
+ * Takes a Creep, room Controller, and a Link. Handles moving the creep
+ * between the Link and the controller. Will gather energy from the Energy
+ * Source and upgrade the controller.
+ */
+export class LinkUpgrader extends Behavior<LinkUpgraderMemory> {
+  /* @override */
+  protected behaviorActions(creep: Creep, mem: LinkUpgraderMemory): boolean {
+    const controller = Game.getObjectById(mem.controllerID);
+    const link = Game.getObjectById(mem.linkID);
+
+    if (!link) {
+      console.log('Upgrader not assigned a valid Link');
+      return false;
+    }
+
+    if (!controller) {
+      console.log('Upgrader not assigned a valid Room Controller');
+      return false;
+    }
+
+    // We don't have a destination position or our current one is occupied
+    if (!mem.destPos) {
+      // We have a source, find a static position around it near the target
+      // console.log(
+      //     creep.name + ' is looking for a new SourceBuild dest location');
+      for (let i: number = link.pos.x - 1; i <= link.pos.x + 1; i++) {
+        for (let j: number = link.pos.y - 1; j <= link.pos.y + 1; j++) {
+          // Cannot stand on top of links
+          if (i === link.pos.x && j === link.pos.y) continue;
+
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const pos = creep.room.getPositionAt(i, j)!;
+          if (pos.lookFor(LOOK_TERRAIN)[0] !== 'wall') {
+            const occupied =
+                creep.room.lookForAt(LOOK_CREEPS, pos.x, pos.y).length > 0;
+            if (!occupied) {
+              mem.destPos = [pos.x, pos.y];
+            }
+          }
+        }
+      }
+    }
+
+    if (mem.destPos) {
+      const creeps =
+          creep.room.lookForAt(LOOK_CREEPS, mem.destPos[0], mem.destPos[1]);
+      if (creeps.length > 0 && creeps[0].id !== creep.id) {
+        // Someone else took our spot, forget it
+        delete mem.destPos;
+      }
+    }
+
+    // Move us to the target destination
+    if (mem.destPos) {
+      const destPos = mem.destPos;
+      if (!creep.pos.inRangeTo(destPos[0], destPos[1], 0)) {
+        creep.moveTo(destPos[0], destPos[1]);
+        return true;
+      }
+
+      // Attempt to refill from energy source
+      if (creep.store.energy < 20 && link.store.energy > 0) {
+        const amount = Math.min(
+            creep.store.getFreeCapacity(),
+            link.store.energy,
+        );
+        creep.withdraw(link, RESOURCE_ENERGY, amount);
+      }
+
+      // Upgrade the controller
+      if (creep.store.energy > 0) {
+        mem.subBehavior = UPGRADER;
+        mem.mem = Upgrader.initMemory(controller);
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  public static initMemory(
+      controller: StructureController,
+      link: StructureLink): LinkUpgraderMemory {
+    return {
+      linkID: link.id,
+      controllerID: controller.id,
+    };
+  }
+}

--- a/src/energy-network/linkConnection.ts
+++ b/src/energy-network/linkConnection.ts
@@ -1,0 +1,32 @@
+/**
+ * This file is a temporary solution to create a one-way link from Storage to
+ * Room Controller to simplify energy distribution.
+ */
+
+/**
+ * operateLinks takes a room, determines the storage and controller pair of
+ * links and pushes energy storage->controller.
+ */
+export function operateLinks(room: Room): void {
+  if (!room.storage || !room.controller || !room.controller.my) return;
+
+  const sLink: StructureLink|null =
+      room.storage.pos.findClosestByRange(
+          FIND_MY_STRUCTURES,
+          {filter: (s) => s.structureType === STRUCTURE_LINK},
+          ) as StructureLink |
+      null;
+  const cLink: StructureLink|null =
+      room.controller.pos.findClosestByRange(
+          FIND_MY_STRUCTURES,
+          {filter: (s) => s.structureType === STRUCTURE_LINK},
+          ) as StructureLink |
+      null;
+
+  if (!sLink || !cLink || sLink.id === cLink.id) return;
+
+  // Add a buffer so upgraders are never interrupted
+  if (cLink.store.energy <= 100) {
+    sLink.transferEnergy(cLink);
+  }
+}

--- a/src/flagConstants.ts
+++ b/src/flagConstants.ts
@@ -96,10 +96,16 @@ export const BASE_OPERATION_FLAG: FlagColor = {
   color: COLOR_BLUE,
   secondaryColor: COLOR_PURPLE,
 };
-/** Reserve Purple/Blue flag color for Extension Groups */
+/** Reserve Purple/Blue flag color for Distribution Missions */
 export const DISTRIBUTION_MISSION_FLAG: FlagColor = {
   color: COLOR_PURPLE,
   secondaryColor: COLOR_BLUE,
+};
+
+/** Reserve Purple/Yellow flag color for Manager Missions */
+export const MANAGER_MISSION_FLAG: FlagColor = {
+  color: COLOR_PURPLE,
+  secondaryColor: COLOR_YELLOW,
 };
 
 /** Reserve Purple/White flag color for Colonization Operation */

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import 'towers/tower'; // Required to initialize Tower Behavior
 
 import {IDLER} from 'behaviors/idler';
 import {registerEnergyNode} from 'energy-network/energyNode';
+import {operateLinks} from 'energy-network/linkConnection';
 import {RoomEnergyNetwork} from 'energy-network/roomEnergyNetwork';
 import {
   BASE_OPERATION_FLAG,
@@ -200,6 +201,11 @@ export const loop = (): void => {
       // Hack, check for existance of network
       if (room.find(FIND_FLAGS, {filter: CORE_ENERGY_NODE_FLAG}).length === 0) {
         roomHealthy = false;
+      }
+
+      // Hack, check for links and push energy to controller if so
+      if (room.controller.level >= 5) {
+        operateLinks(room);
       }
 
       // If we are in autoMode, automatically place oprations/layout flags
@@ -419,7 +425,7 @@ export const loop = (): void => {
   }
 
   // Convert excess CPU into Pixels
-  if (Game.cpu.bucket > 9000) {
+  if (Game.cpu.bucket > 9000 && Game.cpu.generatePixel) {
     // We have CPU to spare
     Game.cpu.generatePixel();
   }

--- a/src/missions/core/manager.ts
+++ b/src/missions/core/manager.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {setCreepBehavior} from 'behaviors/behavior';
+import {Depositer, DEPOSITER} from 'behaviors/depositer';
+import {Fetcher, FETCHER} from 'behaviors/fetcher';
+import {GenerateCreepBodyOptions, TANKER} from 'spawn-system/bodyTypes';
+
+import {Mission, MissionMemory} from '../mission';
+
+interface ManagerMemory extends MissionMemory {
+  storageID: Id<StructureStorage>|null;
+  linkID: Id<StructureLink>|null;
+}
+
+/**
+ * Mission construct to facilitate transfering energy from Storage to the core
+ * Link in the main base.
+ */
+export class ManagerMission extends Mission<ManagerMemory> {
+  protected readonly bodyType = TANKER;
+  // Must have 1 move for tankers
+  protected readonly bodyOptions: GenerateCreepBodyOptions = {
+    max: {carry: 4},
+    min: {
+      move: 1,
+      carry: 0,
+      work: 0,
+      attack: 0,
+      heal: 0,
+      tough: 0,
+      claim: 0,
+    },
+  };
+  protected readonly spawnPriority = 2;
+
+  private storage: StructureStorage|null = null;
+  private link: StructureLink|null = null;
+
+  constructor(flag: Flag) {
+    super(flag);
+  }
+
+  public setStorage(storage: StructureStorage): void {
+    this.storage = storage;
+    this.mem.storageID = storage.id;
+  }
+
+  public setLink(link: StructureLink): void {
+    this.link = link;
+    this.mem.linkID = link.id;
+  }
+
+  /** @override */
+  protected initialMemory(): ManagerMemory {
+    return {
+      creeps: [],
+      storageID: null,
+      linkID: null,
+    };
+  }
+
+  /** @override */
+  public init(): boolean {
+    if (!this.mem.storageID || !this.mem.linkID) {
+      return false;
+    }
+
+    this.storage = Game.getObjectById(this.mem.storageID);
+    this.link = Game.getObjectById(this.mem.linkID);
+    return true;
+  }
+
+  /** Executes one update tick for this mission */
+  public run(): void {
+    if (!this.storage || !this.link) {
+      return;
+    }
+
+    this.creeps.forEach((manager) => {
+      manager.memory.mission = this.name;
+
+      if (manager.store.energy > 0) {
+        if (manager.memory.behavior !== DEPOSITER) {
+          setCreepBehavior(
+              manager, DEPOSITER,
+              Depositer.initMemory(this.link!, RESOURCE_ENERGY));
+          return;
+        }
+      } else {
+        // Limit managers from taking energy from low energy storage
+        if (manager.memory.behavior !== FETCHER &&
+            this.storage!.store.energy >= 100000) {
+          setCreepBehavior(
+              manager, FETCHER,
+              Fetcher.initMemory(this.storage!, RESOURCE_ENERGY));
+          return;
+        }
+      }
+    });
+  }
+
+  private get maxManagers(): number {
+    return 1;
+  }
+
+  /**
+   * @override
+   * Returns true if we need another Distributor.
+   */
+  protected needMoreCreeps(): boolean {
+    if (this.getYoungCreeps().length >= this.maxManagers) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /** @override */
+  /** Returns false Managers are never critical. */
+  protected needMoreCreepsCritical(): boolean {
+    return false;
+  }
+}

--- a/src/missions/index.ts
+++ b/src/missions/index.ts
@@ -7,6 +7,7 @@ import {
   DISTRIBUTION_MISSION_FLAG,
   flagIsColor,
   HARVEST_SOURCE_FLAG,
+  MANAGER_MISSION_FLAG,
   MANUAL_SCOUT_MISSION_FLAG,
   PIONEER_MISSION_FLAG,
   RAID_MISSION_FLAG,
@@ -23,6 +24,7 @@ import {DemolishMission} from './combat/demolish';
 import {RaidMission} from './combat/raid';
 import {BuildMission} from './core/build';
 import {DistributionMission} from './core/distribution';
+import {ManagerMission} from './core/manager';
 import {ManualMission} from './core/manual';
 import {UpgradeMission} from './core/upgrade';
 import {TransportMission} from './logistics/transport';
@@ -51,6 +53,8 @@ global.missions = (flag: Flag): Mission<any>|null => {
     return new UpgradeMission(flag);
   } else if (flagIsColor(flag, DISTRIBUTION_MISSION_FLAG)) {
     return new DistributionMission(flag);
+  } else if (flagIsColor(flag, MANAGER_MISSION_FLAG)) {
+    return new ManagerMission(flag);
   } else if (flagIsColor(flag, CLAIM_MISSION_FLAG)) {
     return new ClaimMission(flag);
   } else if (flagIsColor(flag, ATTACK_CONTROLLER_MISSION_FLAG)) {

--- a/src/spawn-system/bodyTypes.ts
+++ b/src/spawn-system/bodyTypes.ts
@@ -97,6 +97,23 @@ const offRoadHauler: CreepRatio = {
 creepBodyRatios[OR_HAULER] = offRoadHauler;
 
 /**
+ * Tanker
+ * Tankers can move 1 cell per tick when unloaded even off roads. Effectively
+ * immobile when loaded. Should be built with 1 Move Part appended.
+ */
+export const TANKER = 'tanker';
+const tanker: CreepRatio = {
+  attack: 0,
+  carry: 1,
+  claim: 0,
+  heal: 0,
+  move: 0,
+  tough: 0,
+  work: 0,
+};
+creepBodyRatios[TANKER] = tanker;
+
+/**
  * Claimer
  * Claimers can move 1 cell per tick when loaded even off roads
  */


### PR DESCRIPTION
Slapped on a variation of Upgrade Operation which allows use of a Link for transport instead of creep Transport Mission.

More CPU efficient, and more energy efficient if the path to the controller is >20 units.

Requires a manual activation however, set `mem.linkID` on the Upgrade operation once the link is built to work.