### PR TITLE
[Season1] Added Excavation Mission

### DIFF
--- a/src/behaviors/demolish.ts
+++ b/src/behaviors/demolish.ts
@@ -34,11 +34,16 @@ export class Demolisher extends Behavior<DemolishMemory> {
 
       // We have arrived
 
-      // Dismantl the structure
+      // Dismantle the structure
       creep.dismantle(target);
       return false;
     }
     return false;
+  }
+
+  /** Returns the target structure to be demolished */
+  public static getTargetID(mem: DemolishMemory): Id<Structure>|null {
+    return mem.structureID;
   }
 
   public static initMemory(roomname: string, struct: Structure):

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import {Mission} from 'missions/mission';
 import {AllOperations} from 'operations';
 import {BaseOperation} from 'operations/baseOperation';
 import {MiningOperation} from 'operations/miningOperation';
+import {ExcavationMission} from 'season1/excavation';
 import {ScoreCollectMemory, ScoreMission} from 'season1/scoreCollection';
 import {declareOrphan} from 'spawn-system/orphans';
 import {SpawnQueue} from 'spawn-system/spawnQueue';
@@ -57,6 +58,7 @@ export const loop = (): void => {
     upgrade: true,
     enetwork: true,
   };
+  Memory.excavation = Memory.excavation || null;
   global.spawnQueues = global.spawnQueues || {};
 
   installConsoleCommands();
@@ -423,6 +425,14 @@ export const loop = (): void => {
           msn.requestCreep();
           msn.run();
         }
+      }
+
+      // Season 1 Score Excavation
+      if (Memory.excavation) {
+        const msn = new ExcavationMission(Memory.excavation);
+        msn.init();
+        msn.requestCreep();
+        msn.run();
       }
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -426,15 +426,15 @@ export const loop = (): void => {
           msn.run();
         }
       }
-
-      // Season 1 Score Excavation
-      if (Memory.excavation) {
-        const msn = new ExcavationMission(Memory.excavation);
-        msn.init();
-        msn.requestCreep();
-        msn.run();
-      }
     }
+  }
+
+  // Season 1 Score Excavation
+  if (Memory.excavation) {
+    const msn = new ExcavationMission(Memory.excavation);
+    msn.init();
+    msn.requestCreep();
+    msn.run();
   }
 
   // SpawnQueue must execute after missions have a chance request creeps

--- a/src/season1/excavation.ts
+++ b/src/season1/excavation.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {setCreepBehavior} from 'behaviors/behavior';
+import {Demolisher, DEMOLISHER} from 'behaviors/demolish';
+import {IDLER} from 'behaviors/idler';
+import {WORKER} from 'spawn-system/bodyTypes';
+
+export interface ExcavationMemory {
+  room: string|null;    // Spawn Room
+  target: string|null;  // Target Room
+  path: [number, number][];
+  creep: string|null;
+}
+
+/**
+ * Temporary Mission construct to facilitate excavating to a ScoreCollector.
+ *
+ * This mission will request a digger creeps.
+ */
+export class ExcavationMission {
+  protected readonly spawnPriority = 3;
+  protected readonly bodyType = WORKER;
+
+  public spawnSource: Room|null = null;
+  public target: Room|null = null;
+
+  constructor(private mem: ExcavationMemory) {}
+
+  /** @override */
+  public init(): boolean {
+    if (this.mem.room && Game.rooms[this.mem.room]) {
+      this.spawnSource = Game.rooms[this.mem.room];
+    }
+
+    if (this.mem.target && Game.rooms[this.mem.target]) {
+      this.target = Game.rooms[this.mem.target];
+    }
+
+    return true;
+  }
+
+  /** Executes one update tick for this mission */
+  public run(): void {
+    if (!this.spawnSource || !this.mem.path || !this.mem.creep) {
+      return;
+    }
+
+    /**
+     * Spawn a Worker creep with no carry, send it to the dig site.
+     * Dismantle the walls in order.
+     */
+
+    // Direct each creep to pick up or dropoff
+    const creep = Game.creeps[this.mem.creep];
+    if (!creep) return;
+
+    if (creep.memory.behavior === IDLER) {
+      // Pickup newly spawned idle creeps
+      creep.memory.behavior = DEMOLISHER;
+      creep.memory.mission = 'score';
+    }
+
+    if (creep.memory.behavior === DEMOLISHER) {
+      if (!this.target) {
+        // Lost vision of room
+        creep.moveTo(new RoomPosition(25, 25, this.mem.target!), {range: 10});
+      } else {
+        let wall: StructureWall|null = null;
+        const path = this.mem.path;
+
+        while (!wall) {
+          const coords = path.shift();
+          if (!coords) break;
+
+          const structs = this.target.lookAt(coords[0], coords[1]);
+          const wallr = structs.find((s) => {
+            return s.structure && s.structure.structureType === STRUCTURE_WALL;
+          });
+          wall = wallr ? wallr.structure as StructureWall : null;
+        }
+
+        if (!wall) {
+          // We are finished
+          // TODO: Clean up excavation mission
+          return;
+        }
+
+        if (Demolisher.getTargetID(creep.memory.mem) !== wall.id) {
+          // Update fetch target
+          setCreepBehavior(
+              creep,
+              DEMOLISHER,
+              Demolisher.initMemory(this.target.name, wall),
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * @override
+   * Requests a creep if needed for this mission
+   */
+  public requestCreep(): boolean {
+    const creep = Game.creeps[this.mem.creep || ''];
+    if (creep) {
+      return false;
+    }
+
+    // Request a new hauler creep
+    const queue = global.spawnQueues[this.mem.room!];
+    this.mem.creep = queue.requestCreep({
+      bodyRatio: this.bodyType,
+      mission: 'score',
+      priority: this.spawnPriority,
+    });
+    return true;
+  }
+}

--- a/src/season1/excavation.ts
+++ b/src/season1/excavation.ts
@@ -65,7 +65,7 @@ export class ExcavationMission {
         creep.moveTo(new RoomPosition(25, 25, this.mem.target!), {range: 10});
       } else {
         let wall: StructureWall|null = null;
-        const path = this.mem.path;
+        const path = [...this.mem.path];
 
         while (!wall) {
           const coords = path.shift();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,6 +12,7 @@ interface Memory {
   pauseUtil?: number;  // Script paused until this Game Tick
   missions: {[name: string]: any};
   operations: {[name: string]: any};
+  excavation: import('./season1/excavation').ExcavationMemory;
 }
 
 interface RoomMemory {


### PR DESCRIPTION
This is a janky excavation mission for digging out Score Collectors.

- Hardcoded. Must be initialized by hand by the user. User specifies the dig path.
- Only spawns 1 creep when the last dies, no pre-spawning to account for travel time.
- No pulling. Just normal `2W1M` workers.
- Does not recover any of the energy dug. (Optional)